### PR TITLE
Pass supervisord config through secrets

### DIFF
--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -55,7 +55,7 @@ RUN chown -R ckan:ckan-sys /home/ckan
 USER ckan
 
 RUN mkdir -p /home/ckan/var/log/supervisor /home/ckan/var/run /home/ckan/supervisor
-COPY --chown=ckan:ckan-sys supervisor/supervisord.conf /home/ckan/supervisor/supervisord.conf
+# COPY --chown=ckan:ckan-sys supervisor/supervisord.conf /home/ckan/supervisor/supervisord.conf
 
 RUN for d in $APP_DIR/patches/*; do \
         if [ -d $d ]; then \
@@ -65,4 +65,4 @@ RUN for d in $APP_DIR/patches/*; do \
         fi ; \
     done
 
-CMD ["/usr/bin/supervisord", "--configuration", "/home/ckan/supervisor/supervisord.conf"]
+CMD ["/usr/bin/supervisord", "--configuration", "/run/secrets/supervisord_file"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,9 +15,8 @@ services:
       dockerfile: Dockerfile.dev
       args:
         - TZ=${TZ}
-    # env_file:
-    #   - path: ./.env.dev
-    #     required: true
+    secrets:
+     - supervisord_file
     links:
       - db
       - solr
@@ -40,9 +39,6 @@ services:
 
   datapusher:
     image: ckan/ckan-base-datapusher:${DATAPUSHER_VERSION}
-    # env_file:
-    #   - path: ./.env.dev
-    #     required: true
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8800"]
@@ -53,9 +49,6 @@ services:
   db:
     build:
       context: postgresql/
-    # env_file:
-    #   - path: ./.env.dev
-    #     required: true
     environment:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
@@ -74,9 +67,6 @@ services:
 
   solr:
     image: ckan/ckan-solr:${SOLR_IMAGE_VERSION}
-    # env_file:
-    #   - path: ./.env.dev
-    #     required: true
     volumes:
       - solr_data:/var/solr
     restart: unless-stopped
@@ -85,9 +75,10 @@ services:
 
   redis:
     image: redis:${REDIS_VERSION}
-    # env_file:
-    #   - path: ./.env.dev
-    #     required: true
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "-e", "QUIT"]
+
+secrets:
+  supervisord_file:
+    file: ckan/supervisor/supervisord.conf


### PR DESCRIPTION
secrets are still in `.env.dev` file and `supervisord.conf`. However, these are only passed through the file system upon container launch.

The `ckan-docker-db` image will still have the secrets inside its env, however I'm not sure if there's a way around this. The specific secrets are listed in the `docker-compose.dev.yml` file (under `environment:`).

The other containers (solr, datapushed, redis) don't contain any secrets.

